### PR TITLE
Update sass-loader to 3.2.3

### DIFF
--- a/extensions/roc-plugin-style-sass/package.json
+++ b/extensions/roc-plugin-style-sass/package.json
@@ -29,7 +29,7 @@
     "bourbon": "~4.2.6",
     "node-sass": "~3.10.0",
     "roc": "^1.0.0-rc.12",
-    "sass-loader": "~3.1.2"
+    "sass-loader": "~3.2.3"
   },
   "devDependencies": {
     "babel-eslint": "~6.1.2",


### PR DESCRIPTION
Adds support for prepending data, https://github.com/webpack-contrib/sass-loader/tree/v3.2.1#environment-variables