### PR TITLE
Upgrade node-sass to ^4.5.0

### DIFF
--- a/extensions/roc-plugin-style-sass/package.json
+++ b/extensions/roc-plugin-style-sass/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "bourbon": "~4.2.6",
-    "node-sass": "~3.10.0",
+    "node-sass": "^4.5.0",
     "roc": "^1.0.0-rc.12",
     "sass-loader": "~3.2.3"
   },


### PR DESCRIPTION
We're having issues running node 8 because of the lack of binaries for the old node-sass versions.

I've manually tested 4.5.3 on two of our projects, and both build and dev works flawlessly. Gives the impression to be quite a lot faster as well.