### PR TITLE
Upgrade sass-loader to ^4.1.1

### DIFF
--- a/extensions/roc-plugin-style-sass/package.json
+++ b/extensions/roc-plugin-style-sass/package.json
@@ -29,7 +29,7 @@
     "bourbon": "~4.2.6",
     "node-sass": "^4.5.0",
     "roc": "^1.0.0-rc.12",
-    "sass-loader": "~3.2.3"
+    "sass-loader": "^4.1.1"
   },
   "devDependencies": {
     "babel-eslint": "~6.1.2",


### PR DESCRIPTION
The breaking change between 3 and 4 only applies if one uses resolve-url-loader, something we are not meaning that this update is safe.